### PR TITLE
Update Regex for links

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -193,7 +193,7 @@ function pushMessage(args) {
 	textEl.classList.add('text')
 
 	textEl.textContent = args.text || ''
-	textEl.innerHTML = textEl.innerHTML.replace(/(\?|https?:\/\/)\S+?(?=[,.!?:)]?\s|$)/g, parseLinks)
+	textEl.innerHTML = textEl.innerHTML.replace(/(\s|^)(\?|https?:\/\/|www\.)\S+/gi, parseLinks)
 
 	if ($('#parse-latex').checked) {
 		// Temporary hotfix for \rule spamming, see https://github.com/Khan/KaTeX/issues/109

--- a/client/client.js
+++ b/client/client.js
@@ -193,7 +193,7 @@ function pushMessage(args) {
 	textEl.classList.add('text')
 
 	textEl.textContent = args.text || ''
-	textEl.innerHTML = textEl.innerHTML.replace(/(\s|^)(\?|https?:\/\/|www\.)\S+/gi, parseLinks)
+	textEl.innerHTML = textEl.innerHTML.replace(/(?!\s)(\?|https?:\/\/|www\.)\S+/gi, parseLinks)
 
 	if ($('#parse-latex').checked) {
 		// Temporary hotfix for \rule spamming, see https://github.com/Khan/KaTeX/issues/109


### PR DESCRIPTION
example of currently faulty link:
https://share.lyka.pro/2017-4-5-8.png
notice how the last ')' is not part of the link, this only occurs in multiline scenario's
also reduced the regex complexity with redundant components
also allowing for www. links